### PR TITLE
Don't render whitespaces

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -1,6 +1,6 @@
 // Place your settings in this file to overwrite the default settings
 {
-    "editor.renderWhitespace": true,
+    "editor.renderWhitespace": false,
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
     "editor.wrappingColumn": 120,


### PR DESCRIPTION
The cause of mental disorder is often unclear but in this case I guess python - where indentation matters - is the reason. Normal people don't want to see whitespaces being rendered.
